### PR TITLE
Avoid extra startViews

### DIFF
--- a/packages/react-ux-capture/src/UXCaptureStartView.jsx
+++ b/packages/react-ux-capture/src/UXCaptureStartView.jsx
@@ -35,8 +35,38 @@ const makeZones = (props: Props): Array<ZoneConfig> =>
 		},
 	].filter(({ marks }: ZoneConfig) => marks && marks.length > 0);
 
+const isSameArray = (a?: Array<string>, b?: Array<string>): boolean => {
+	return JSON.stringify(a) === JSON.stringify(b);
+};
 export default class UXCaptureStartView extends React.Component<Props> {
 	zones = makeZones(this.props);
+
+	shouldComponentUpdate(nextProps: Props) {
+		const {
+			destinationVerified,
+			primaryContentDisplayed,
+			primaryActionAvailable,
+			secondaryContentDisplayed,
+		} = this.props;
+
+		const {
+			destinationVerified: nextDestinationVerified,
+			primaryContentDisplayed: nextPrimaryContentDisplayed,
+			primaryActionAvailable: nextPrimaryActionAvailable,
+			secondaryContentDisplayed: nextSecondaryContentDisplayed,
+		} = nextProps;
+
+		if (
+			isSameArray(destinationVerified, nextDestinationVerified) &&
+			isSameArray(primaryContentDisplayed, nextPrimaryContentDisplayed) &&
+			isSameArray(primaryActionAvailable, nextPrimaryActionAvailable) &&
+			isSameArray(secondaryContentDisplayed, nextSecondaryContentDisplayed)
+		) {
+			return false;
+		}
+
+		return true;
+	}
 	componentDidUpdate(prev: Props) {
 		// updated on client - if mark name has changed, clear old mark and trigger new
 		if (

--- a/packages/react-ux-capture/src/uxCaptureStartView.test.jsx
+++ b/packages/react-ux-capture/src/uxCaptureStartView.test.jsx
@@ -144,4 +144,48 @@ describe('UXCaptureStartView', () => {
 			expect(renderComponent(props)).toMatchSnapshot();
 		});
 	});
+	describe('shouldComponentUpdate', () => {
+		it.each([
+			'destinationVerified',
+			'primaryContentDisplayed',
+			'primaryActionAvailable',
+			'secondaryContentDisplayed',
+		])('returns true when prop has changed', prop => {
+			const initialProps = {};
+			initialProps[prop] = ['ux-1', 'ux-2'];
+			const nextProps = {};
+			nextProps[prop] = ['ux-1', 'ux-2', 'ux-3'];
+			const wrapper = renderComponent(initialProps);
+
+			expect(wrapper.instance().shouldComponentUpdate(nextProps)).toBeTruthy();
+		});
+		it.each([
+			'destinationVerified',
+			'primaryContentDisplayed',
+			'primaryActionAvailable',
+			'secondaryContentDisplayed',
+		])('returns false when props has not changed', prop => {
+			const initialProps = {};
+			initialProps[prop] = ['ux-1', 'ux-2'];
+			const wrapper = renderComponent(initialProps);
+
+			expect(
+				wrapper.instance().shouldComponentUpdate(initialProps)
+			).toBeTruthy();
+		});
+		it.each([
+			'destinationVerified',
+			'primaryContentDisplayed',
+			'primaryActionAvailable',
+			'secondaryContentDisplayed',
+		])('returns false when props has not changed even with a new array', prop => {
+			const initialProps = {};
+			initialProps[prop] = ['ux-1', 'ux-2'];
+			const nextProps = {};
+			nextProps[prop] = ['ux-1', 'ux-2'];
+			const wrapper = renderComponent(initialProps);
+
+			expect(wrapper.instance().shouldComponentUpdate(nextProps)).toBeTruthy();
+		});
+	});
 });


### PR DESCRIPTION
If you don't pass constants to `<UXCaptureStartView />`, it calls `UXCapture.startView` on every render. This prevents that.