### PR TITLE
Ux image fixes

### DIFF
--- a/packages/react-ux-capture-example/package.json
+++ b/packages/react-ux-capture-example/package.json
@@ -1,13 +1,13 @@
 {
 	"name": "@meetup/react-ux-capture-example",
-	"version": "1.1.1",
+	"version": "1.2.0",
 	"author": "Meetup",
 	"license": "MIT",
 	"publishConfig": {
 		"access": "public"
 	},
 	"dependencies": {
-		"@meetup/react-ux-capture": "^1.1.1",
+		"@meetup/react-ux-capture": "^1.2.0",
 		"react": "^16.7.0",
 		"react-dom": "^16.7.0",
 		"react-router-dom": "^4.3.1",

--- a/packages/react-ux-capture/package.json
+++ b/packages/react-ux-capture/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meetup/react-ux-capture",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "React bindings for the ux-capture UX speed library",
   "main": "index.js",
   "repository": "git@github.com:meetup/ux-capture.git",
@@ -18,7 +18,7 @@
     "react": "^16.0.0"
   },
   "dependencies": {
-    "@meetup/ux-capture": "^4.2.1"
+    "@meetup/ux-capture": "^4.2.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/packages/react-ux-capture/src/UXCaptureImageLoad.jsx
+++ b/packages/react-ux-capture/src/UXCaptureImageLoad.jsx
@@ -64,12 +64,10 @@ const UXCaptureImageLoad = (props: Props) => {
 	const onload = getOnLoadJS(mark);
 	const otherImgAttrs = getPropsAsHTMLAttrs(other);
 
-	const inlineStyles = style
-		? `style="${getCSSStringFromStyleObject(style)}""`
-		: '';
+	const inlineStyles = style ? `style="${getCSSStringFromStyleObject(style)}"` : '';
 
 	return (
-		<div
+		<span
 			dangerouslySetInnerHTML={{
 				__html: `
 				<img src="${src}" onload="${onload}" ${inlineStyles} ${otherImgAttrs} />

--- a/packages/react-ux-capture/src/UXCaptureImageLoad.jsx
+++ b/packages/react-ux-capture/src/UXCaptureImageLoad.jsx
@@ -42,7 +42,7 @@ export const getPropsAsHTMLAttrs = (props: React$ElementProps<'img'>): string =>
 		.join(' ');
 };
 
-export const getCSSStringFromStyleObject = style => {
+export const getCSSStringFromStyleObject = (style: Object): string => {
 	return style
 		? Object.keys(style)
 				.map(s => {

--- a/packages/react-ux-capture/src/__snapshots__/uxCaptureImageLoad.test.jsx.snap
+++ b/packages/react-ux-capture/src/__snapshots__/uxCaptureImageLoad.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`UXCaptureImageLoad renders component markup 1`] = `
-<div
+<span
   dangerouslySetInnerHTML={
     Object {
       "__html": "

--- a/packages/react-ux-capture/src/__snapshots__/uxCaptureImageLoad.test.jsx.snap
+++ b/packages/react-ux-capture/src/__snapshots__/uxCaptureImageLoad.test.jsx.snap
@@ -5,7 +5,7 @@ exports[`UXCaptureImageLoad renders component markup 1`] = `
   dangerouslySetInnerHTML={
     Object {
       "__html": "
-				<img id=\\"ux-capture-ux-image-load-logo\\" src=\\"/foo.png\\" onload=\\" if (window.UXCapture && !window.UXCapture['ux-image-load-logo-LOADED']) { window.UXCapture.mark('ux-image-load-logo'); window.UXCapture['ux-image-load-logo-LOADED'] = true; } \\" class=\\"someClass\\" alt=\\"altText\\" height=\\"50\\" />
+				<img src=\\"/foo.png\\" onload=\\" if (window.UXCapture && !window.UXCapture['ux-image-load-logo-LOADED']) { window.UXCapture.mark('ux-image-load-logo'); window.UXCapture['ux-image-load-logo-LOADED'] = true; } \\"  class=\\"someClass\\" alt=\\"altText\\" height=\\"50\\" />
 			",
     }
   }

--- a/packages/ux-capture/package.json
+++ b/packages/ux-capture/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meetup/ux-capture",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Browser instrumentation helper that makes it easier to capture UX speed metrics",
   "main": "lib/ux-capture.min.js",
   "directories": {


### PR DESCRIPTION
This removes the extra double quote I fat-fingered, and replaces the `div` wrapping the `img` in `UXCaptureImageLoad`, so as to not create a box and potentially impact the host UI. Ideally there would be no wrapper, but how to achieve that is not immediately obvious to me.