### PR TITLE
Optional timestamp

### DIFF
--- a/packages/ux-capture/src/ExpectedMark.js
+++ b/packages/ux-capture/src/ExpectedMark.js
@@ -20,10 +20,10 @@ function ExpectedMark(props) {
  *
  * @param {string} name
  */
-ExpectedMark.create = function(name, listener) {
+ExpectedMark.create = function(name, listener, recordTimestamps) {
 	// create new mark only if one does not exist
 	if (!_expectedMarks[name]) {
-		var mark = new ExpectedMark({ name });
+		var mark = new ExpectedMark({ name, recordTimestamps });
 		if (listener) {
 			mark.addOnMarkListener(listener);
 		}
@@ -33,8 +33,8 @@ ExpectedMark.create = function(name, listener) {
 	return _expectedMarks[name];
 };
 
-ExpectedMark.record = function(name, waitForNextPaint = true) {
-	const mark = ExpectedMark.create(name);
+ExpectedMark.record = function(name, waitForNextPaint = true, recordTimestamps) {
+	const mark = ExpectedMark.create(name, null, recordTimestamps);
 	if (waitForNextPaint) {
 		// in many cases, we intend to record a mark when an element paints, not
 		// at the moment the mark.record() call is made in in JS
@@ -71,8 +71,11 @@ ExpectedMark.prototype._mark = function() {
 	 * These timestamps are counted from timeline recording start
 	 * while UserTiming marks are counted from navigationStart event.
 	 * In perf visualizations, they all will be offset by the same amount of time
+	 *
+	 * This is optional now that Chrome 87 supports mark visualization
 	 */
 	if (
+		this.props.recordTimestamps &&
 		typeof window.console !== 'undefined' &&
 		typeof window.console.timeStamp !== 'undefined'
 	) {

--- a/packages/ux-capture/src/UXCapture.js
+++ b/packages/ux-capture/src/UXCapture.js
@@ -21,6 +21,7 @@ let _onMark = NOOP;
 let _onMeasure = NOOP;
 let _view;
 let _startMarkName = NAVIGATION_START_MARK_NAME;
+let _recordTimestamps = false;
 
 const UXCapture = {
 	/**
@@ -46,6 +47,7 @@ const UXCapture = {
 		_onMark = config.onMark || NOOP;
 		_onMeasure = config.onMeasure || NOOP;
 		_startMarkName = NAVIGATION_START_MARK_NAME;
+		_recordTimestamps = config.recordTimestamps || false;
 	},
 
 	/**
@@ -78,6 +80,7 @@ const UXCapture = {
 			onMark: _onMark,
 			onMeasure: _onMeasure,
 			startMarkName: _startMarkName,
+			recordTimestamps: _recordTimestamps,
 			zoneConfigs,
 		});
 	},

--- a/packages/ux-capture/src/View.js
+++ b/packages/ux-capture/src/View.js
@@ -35,6 +35,7 @@ View.prototype.createZone = function(zoneConfig) {
 				onMark: this.props.onMark,
 				onMeasure: this.props.onMeasure,
 				startMarkName: this.props.startMarkName,
+				recordTimestamps: this.props.recordTimestamps,
 			},
 			zoneConfig
 		)

--- a/packages/ux-capture/src/Zone.js
+++ b/packages/ux-capture/src/Zone.js
@@ -28,7 +28,11 @@ function Zone(props) {
 			this.props.onMark(markName);
 		};
 
-		const mark = ExpectedMark.create(markName, markListener);
+		const mark = ExpectedMark.create(
+			markName,
+			markListener,
+			this.props.recordTimestamps
+		);
 
 		const measureListener = completeMark => {
 			if (this.marks.every(({ mark }) => mark.marked)) {


### PR DESCRIPTION
Makes `console.timestamp()` call optional (off by default).

As it got easier to test individual marks in Chrome DevTools using Performance Timeline ([see updated testing docs](https://github.com/ux-capture/ux-capture/tree/main/docs/testing-instrumentation)), we don't need to use a proprietary `console.timestamp()` method as a clutch.