### PR TITLE
A function to retrieve current view's configuration object

### DIFF
--- a/packages/ux-capture/docs/ux-capture-js-api-spec.md
+++ b/packages/ux-capture/docs/ux-capture-js-api-spec.md
@@ -139,39 +139,3 @@ A collection of `ExpectedMarks` that fires `onMeasure` when every corresponding 
 A class that ensures each unique mark name corresponds to a single call to the `window.performance.mark` when `UXCapture.mark` is called.
 
 Also provides interface for clearing/destroying marks.
-
-### General design pattern
-Each class constructor takes a configuration object as an argument, similar to React component classes. This object is assigned to the instance’s
-`this.props` property. This ‘standard’ behavior is provided by a `UXBase` class and allows most/all classes to avoid explicitly defining a constructor
-at all – instead, class properties can assign values based on `this.props`.
-
-Example implementation:
-```javascript
-class UXBase {
- constructor(props) {
- this.props = props;
- }
-}
-
-class ExpectedMark extends UXBase {
- // this.name not needed - use `this.props.name`
- // no constructor
-}
-
-class View extends UXBase {
- this.expectedZones = this.props.zoneConfigs.map(...);
- // no constructor
-}
-
-class Zone extends UXBase {
- marks = this.props.marks.map(...);
- // measureName not needed - use this.props.name
- // onMeasure not needed - use this.props.onMeasure
- // onMark not needed - use this.props.onMark
- // startMarkName not needed (default to 'navigationStart')
- // no constructor
-}
-```
-
-The `UXBase` class both reduces boilerplate and enforces structural consistency. Since it also matches React's constructor behavior it would also
-feel familiar anyone with React experience.

--- a/packages/ux-capture/docs/ux-capture-js-api-spec.md
+++ b/packages/ux-capture/docs/ux-capture-js-api-spec.md
@@ -28,6 +28,7 @@ export interface UXCapture {
  static clearMarks: (name?) => void,
  static startTransition: () => void,
  static startView: (Array<ZoneConfig>) => void,
+ static getViewConfig: () => Array<ZoneConfig>,
  static updateView: (Array<ZoneConfig>) => void, // lazily-defined marks
  static mark: (name: string, waitForNextPaint?: boolean) => void
 }
@@ -106,6 +107,11 @@ Creates new `View` and stores a reference to the instance
 Merge new `zoneConfig`s with existing view’s `zoneConfig`s
 - a new `Zone` will be created for any name that has not already been defined
 - The `ExpectedMark`s will be merged with any existing `Zone` with the same name
+
+### `UXCapture.getViewConfig`
+Returns current view's configuration as it was passed to `startView()` or updated later using `updateView()`.
+
+This is useful for debugging your instrumentation in browser console or for additional tools like [`progressive-enhancement-designer`](https://github.com/ux-capture/progressive-enhancement-designer) to consume as input.
 
 ## Public API Requirements
 1. Define views before transition happens to assure minimal lookup time for this information, e.g. without any network requests to load the code required for the view

--- a/packages/ux-capture/package.json
+++ b/packages/ux-capture/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ux-capture/ux-capture",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Browser instrumentation helper that makes it easier to capture UX speed metrics",
   "main": "lib/ux-capture.min.js",
   "directories": {

--- a/packages/ux-capture/src/UXCapture.js
+++ b/packages/ux-capture/src/UXCapture.js
@@ -101,6 +101,15 @@ const UXCapture = {
 		_view.update(zoneConfigs);
 	},
 
+	/**
+	 * Returns view configuration object or null if there is no current view
+	 *
+	 * @returns {object}|null
+	 */
+	getViewConfig: () => {
+		return _view ? _view.getZoneConfigs() : null;
+	},
+
 	/*
 	 * Start view transition will end/destroy current View and set a new 'start mark'
 	 * Existing marks are _not_ removed automatically (they may outlive the view).

--- a/packages/ux-capture/src/View.js
+++ b/packages/ux-capture/src/View.js
@@ -15,6 +15,9 @@ function View(props) {
 // TODO: determine if we need to support appending new marks
 // to exisiting zones or new zones or both
 View.prototype.update = function (zoneConfigs) {
+	// Append configuration, same way we append the zones themselves
+	this.props.zoneConfigs.push.apply(this.props.zoneConfigs, zoneConfigs);
+
 	// Append new zones to existing config
 	this.expectedZones.push.apply(this.expectedZones, this.setZones(zoneConfigs));
 };

--- a/packages/ux-capture/src/View.js
+++ b/packages/ux-capture/src/View.js
@@ -42,4 +42,8 @@ View.prototype.createZone = function (zoneConfig) {
 	);
 };
 
+View.prototype.getZoneConfigs = function () {
+	return this.props.zoneConfigs;
+};
+
 export default View;

--- a/packages/ux-capture/src/View.js
+++ b/packages/ux-capture/src/View.js
@@ -16,10 +16,10 @@ function View(props) {
 // to exisiting zones or new zones or both
 View.prototype.update = function (zoneConfigs) {
 	// Append configuration, same way we append the zones themselves
-	this.props.zoneConfigs.push.apply(this.props.zoneConfigs, zoneConfigs);
+	this.props.zoneConfigs.push(...zoneConfigs);
 
 	// Append new zones to existing config
-	this.expectedZones.push.apply(this.expectedZones, this.setZones(zoneConfigs));
+	this.expectedZones.push(...this.setZones(zoneConfigs));
 };
 
 View.prototype.setZones = function (zoneConfigs) {

--- a/packages/ux-capture/test/ux-capture.test.js
+++ b/packages/ux-capture/test/ux-capture.test.js
@@ -13,6 +13,7 @@ describe('ux-capture', () => {
 			expect(UXCapture.startView).toBeDefined();
 			expect(UXCapture.updateView).toBeDefined();
 			expect(UXCapture.startTransition).toBeDefined();
+			expect(UXCapture.getViewConfig).toBeDefined();
 			expect(UXCapture.mark).toBeDefined();
 		});
 	});

--- a/packages/ux-capture/test/uxCapture.test.js
+++ b/packages/ux-capture/test/uxCapture.test.js
@@ -143,6 +143,31 @@ describe('UXCapture', () => {
 			expect(UXCapture.getViewConfig()).toEqual(zoneConfigs);
 		});
 
+		it('Should return new view config after startTransition() and subsequent startView()', () => {
+			const firstViewConfig = [
+				{
+					name: MOCK_MEASURE_1,
+					marks: [MOCK_MARK_1_1],
+				},
+			];
+
+			const secondViewConfig = [
+				{
+					name: MOCK_MEASURE_1,
+					marks: [MOCK_MARK_1_2],
+				},
+			];
+
+
+			UXCapture.startView(firstViewConfig);
+			expect(UXCapture.getViewConfig()).toEqual(firstViewConfig);
+
+			UXCapture.startTransition();
+
+			UXCapture.startView(secondViewConfig);
+			expect(UXCapture.getViewConfig()).toEqual(secondViewConfig);
+		});
+
 		it("should return updated configuration when zone config is updated", () => {
 			UXCapture.startView([
 				{

--- a/packages/ux-capture/test/uxCapture.test.js
+++ b/packages/ux-capture/test/uxCapture.test.js
@@ -112,6 +112,65 @@ describe('UXCapture', () => {
 		});
 	});
 
+	describe('getViewConfig', () => {
+		it('Should return null if there is no config yet', () => {
+			expect(UXCapture.getViewConfig()).toEqual(null);
+		});
+
+		it('Should return null after startTransition() but before startView()', () => {
+			UXCapture.startView([
+				{
+					name: MOCK_MEASURE_1,
+					marks: [],
+				},
+			]);
+
+			UXCapture.startTransition();
+
+			expect(UXCapture.getViewConfig()).toEqual(null);
+		});
+
+		it('Should return configuration object as it was passed in', () => {
+			const zoneConfigs = [
+				{
+					name: MOCK_MEASURE_1,
+					marks: [],
+				},
+			];
+
+			UXCapture.startView(zoneConfigs);
+
+			expect(UXCapture.getViewConfig()).toEqual(zoneConfigs);
+		});
+
+		it("should return updated configuration when zone config is updated", () => {
+			UXCapture.startView([
+				{
+					name: MOCK_MEASURE_1,
+					marks: [],
+				},
+			]);
+
+			UXCapture.updateView([
+				{
+					name: MOCK_MEASURE_2,
+					marks: [],
+				},
+			]);
+
+			expect(UXCapture.getViewConfig()).toEqual([
+				{
+					name: MOCK_MEASURE_1,
+					marks: [],
+				},
+				{
+					name: MOCK_MEASURE_2,
+					marks: [],
+				},
+			])
+		})
+	});
+
 	describe('create', () => {
 		it('Should throw an error if non-object is passed', () => {
 			expect(() => {


### PR DESCRIPTION
`UXCapture.getViewConfig()` to retrieve current views's configuration (if set already, e.g. after `UXCapture.startView()` call was made).

Returns configuration object as is, changing it should not do anything useful though, should be used read-only.