### PR TITLE
[WEBPERF-24]: Updating readme & adding early tasks test to UX capture core lib

### DIFF
--- a/packages/ux-capture/README.md
+++ b/packages/ux-capture/README.md
@@ -144,7 +144,7 @@ Call UXCapture.mark in the HTML markup for each ‘mark’ name passed into
 ...
 ```
 
-**NOTE:** It is OK to fire marks before view is configured. This still works because UXCapture remembers all the recorded marks irrespective of whether it was first declared or not because ExpectedMark instances are created and cached when UXCapture.mark() is called. When UXCapture.startView() is executed and zone-mark dependencies are established, mark's callbacks are immediately fired if mark was already cached and marked as marked.
+**NOTE:** UXCapture will record and remember marks even before the page's UXCapture configuration has executed. This still works because UXCapture remembers all the recorded marks irrespective of whether or not it was first declared because ExpectedMark instances are created and cached when `UXCapture.mark()` is called. When `UXCapture.startView()` is executed and zone-mark dependencies are established, mark's callbacks are immediately fired if mark was already cached and marked as marked.
 
 ### Step 6: SPA views / transitions (if applicable)
 

--- a/packages/ux-capture/test/uxCapture.test.js
+++ b/packages/ux-capture/test/uxCapture.test.js
@@ -675,42 +675,35 @@ describe('UXCapture', () => {
 			).toBeTruthy();
 		});
 	});
-});
 
-describe("UXCapture early tasks", () => {
-	beforeEach(() => {
-		window.performance.clearMarks();
-	});
-
-	afterEach(() => {
-		UXCapture.destroy();
-	});
-
-	it("supports firing of marks before calling create or startView" , () => {
-		const config = [
-			{
-				name: MOCK_MEASURE_1,
-				marks: [MOCK_MARK_1_1, MOCK_MARK_1_2],
-			},
-		];
-		expect(() => {
+	describe("Early tasks", () => {
+		beforeEach(() => {
+			UXCapture.destroy();
+		});
+		it("supports firing of marks before calling create or startView" , () => {
+			const config = [
+				{
+					name: MOCK_MEASURE_1,
+					marks: ['early_mark', MOCK_MARK_1_1],
+				},
+			];
+			// recording the mark before creation
+			ExpectedMark.record('early_mark');
+			expect(
+				window.performance
+					.getEntriesByType('mark')
+					.find(mark => mark.name === 'early_mark')
+			).toBeTruthy();
+			UXCapture.create({onMark, onMeasure});
+			UXCapture.startView(config);
 			UXCapture.mark(MOCK_MARK_1_1);
-		}).not.toThrow();
-		UXCapture.mark(MOCK_MARK_1_1);
-		expect(onMark).toHaveBeenCalledTimes(1);
-		expect(
-			window.performance
-				.getEntriesByType('mark')
-				.find(mark => mark.name === MOCK_MARK_1_1)
-		).toBeTruthy();
-		UXCapture.create({onMark, onMeasure});
-		UXCapture.startView(config);
-		UXCapture.mark(MOCK_MARK_1_2);
-		expect(
-			window.performance
-				.getEntriesByType('measure')
-				.find(measure => measure.name === MOCK_MEASURE_1)
-		).toBeTruthy();
-		expect(onMark).toHaveBeenCalledTimes(2);
+			expect(
+				window.performance
+					.getEntriesByType('measure')
+					.find(measure => measure.name === MOCK_MEASURE_1)
+			).toBeTruthy();
+			expect(onMark).toHaveBeenCalledTimes(1);
+			expect(onMeasure).toHaveBeenCalledTimes(1);
+		});
 	});
 });


### PR DESCRIPTION
This PR adds a test to check that marks can be fired off before creation or start view have been called. 

Also updates the readme to explain why this is possible.